### PR TITLE
Adds Query Params

### DIFF
--- a/queries/parameters.go
+++ b/queries/parameters.go
@@ -4,29 +4,24 @@ import (
 	"strconv"
 )
 
-type Paramable interface {
-	GetParams() string
+type Param interface {
+	ToParamString() string
 }
 
-// TODO: This is a nieve approach and won't scale - perhaps
-// ShowParams should have an array of params that each know how
-// to be coerced to a string value (i.e. Param structs adhering
-// to "Stringify" interface?
-type ShowParams struct {
-	ShowFields   string
-	ShowTags     string
-	ShowElements string
-	ShowBlocks   string
-	ShowSection  bool
+type StringParam struct {
+	Key   string
+	Value string
 }
 
-func (showParams ShowParams) GetParams() string {
-	paramString := "?" +
-		"show-fields=" + showParams.ShowFields +
-		"&show-tags=" + showParams.ShowTags +
-		"&show-elements=" + showParams.ShowElements +
-		"&show-blocks=" + showParams.ShowBlocks +
-		"&show-section=" + strconv.FormatBool(showParams.ShowSection)
+func (p StringParam) ToParamString() string {
+	return p.Key + "=" + p.Value
+}
 
-	return paramString
+type BoolParam struct {
+	Key   string
+	Value bool
+}
+
+func (p BoolParam) ToParamString() string {
+	return p.Key + "=" + strconv.FormatBool(p.Value)
 }

--- a/queries/parameters.go
+++ b/queries/parameters.go
@@ -1,0 +1,28 @@
+package queries
+
+import (
+	"strconv"
+)
+
+type Paramable interface {
+	GetParams() string
+}
+
+type ShowParams struct {
+	ShowFields   string
+	ShowTags     string
+	ShowElements string
+	ShowBlocks   string
+	ShowSection  bool
+}
+
+func (showParams ShowParams) GetParams() string {
+	paramString := "?" +
+		"show-fields=" + showParams.ShowFields +
+		"show-tags=" + showParams.ShowTags +
+		"show-elements=" + showParams.ShowElements +
+		"show-blocks=" + showParams.ShowBlocks +
+		"show-section=" + strconv.FormatBool(showParams.ShowSection)
+
+	return paramString
+}

--- a/queries/parameters.go
+++ b/queries/parameters.go
@@ -8,6 +8,10 @@ type Paramable interface {
 	GetParams() string
 }
 
+// TODO: This is a nieve approach and won't scale - perhaps
+// ShowParams should have an array of params that each know how
+// to be coerced to a string value (i.e. Param structs adhering
+// to "Stringify" interface?
 type ShowParams struct {
 	ShowFields   string
 	ShowTags     string
@@ -19,10 +23,10 @@ type ShowParams struct {
 func (showParams ShowParams) GetParams() string {
 	paramString := "?" +
 		"show-fields=" + showParams.ShowFields +
-		"show-tags=" + showParams.ShowTags +
-		"show-elements=" + showParams.ShowElements +
-		"show-blocks=" + showParams.ShowBlocks +
-		"show-section=" + strconv.FormatBool(showParams.ShowSection)
+		"&show-tags=" + showParams.ShowTags +
+		"&show-elements=" + showParams.ShowElements +
+		"&show-blocks=" + showParams.ShowBlocks +
+		"&show-section=" + strconv.FormatBool(showParams.ShowSection)
 
 	return paramString
 }

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -13,7 +13,7 @@ type Query interface {
 }
 
 type ItemQuery struct {
-	Params   []Paramable
+	Params   []Param
 	Id       string
 	Response *content.ItemResponse
 }
@@ -27,13 +27,10 @@ func NewItemQuery(Id string) *ItemQuery {
 
 // TODO: Need to test params to url
 func (itemQuery ItemQuery) GetUrl(base string) string {
-	paramString := ""
 
-	for i, v := range itemQuery.Params {
-		if v != nil {
-			paramable := itemQuery.Params[i]
-			paramString += paramable.GetParams()
-		}
+	paramString := "?"
+	for _, v := range itemQuery.Params {
+		paramString += v.ToParamString() + "&"
 	}
 
 	url := base + itemQuery.Id + paramString

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -13,6 +13,7 @@ type Query interface {
 }
 
 type ItemQuery struct {
+	Params   []Paramable
 	Id       string
 	Response *content.ItemResponse
 }
@@ -25,7 +26,20 @@ func NewItemQuery(Id string) *ItemQuery {
 }
 
 func (itemQuery ItemQuery) GetUrl(base string) string {
-	return base + itemQuery.Id
+	paramString := ""
+
+	for i, v := range itemQuery.Params {
+		if v != nil {
+			paramable := itemQuery.Params[i]
+			paramString += paramable.GetParams()
+		}
+	}
+
+	url := base + itemQuery.Id + paramString
+
+	println(url)
+
+	return url
 }
 
 func (itemQuery ItemQuery) Deserialize(deser *thrift.TDeserializer, r io.ReadCloser) error {

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -25,6 +25,7 @@ func NewItemQuery(Id string) *ItemQuery {
 	return &itemQuery
 }
 
+// TODO: Need to test params to url
 func (itemQuery ItemQuery) GetUrl(base string) string {
 	paramString := ""
 

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -25,17 +25,24 @@ func NewItemQuery(Id string) *ItemQuery {
 	return &itemQuery
 }
 
-// TODO: Need to test params to url
-func (itemQuery ItemQuery) GetUrl(base string) string {
+func createParamString(params []Param) string {
+	if len(params) == 0 {
+		return ""
+	}
 
 	paramString := "?"
-	for _, v := range itemQuery.Params {
+
+	for _, v := range params {
 		paramString += v.ToParamString() + "&"
 	}
 
-	url := base + itemQuery.Id + paramString
+	return paramString[:len(paramString)-1]
+}
 
-	println(url)
+func (itemQuery ItemQuery) GetUrl(base string) string {
+
+	paramString := createParamString(itemQuery.Params)
+	url := base + itemQuery.Id + paramString
 
 	return url
 }

--- a/queries/queries_test.go
+++ b/queries/queries_test.go
@@ -30,7 +30,8 @@ func TestItemQueryDeserialize(t *testing.T) {
 	deser := thrift.NewTDeserializer()
 
 	serialItemResponse, err := serial.Write(&itemResponse)
-	itemResponseReadCloser := ioutil.NopCloser(bytes.NewReader(serialItemResponse))
+	itemResponseReadCloser := ioutil.NopCloser(
+		bytes.NewReader(serialItemResponse))
 
 	if err != nil {
 		t.Error(err)

--- a/queries/queries_test.go
+++ b/queries/queries_test.go
@@ -46,3 +46,20 @@ func TestItemQueryDeserialize(t *testing.T) {
 	}
 
 }
+
+func TestItemQueryGetUrlParams(t *testing.T) {
+	t.Log("Constructing query url with params")
+
+	itemQuery := queries.NewItemQuery("id")
+	stringParam := queries.StringParam{
+		Key:   "show-example",
+		Value: "value",
+	}
+
+	itemQuery.Params = []queries.Param{&stringParam}
+	url := itemQuery.GetUrl("http://www.example.com/")
+
+	if url != "http://www.example.com/id?show-example=value" {
+		t.Error("Incorrect query url for itemQuery.GetUrl")
+	}
+}


### PR DESCRIPTION
Reproducing essential param passing functionality as per: https://github.com/guardian/content-api-scala-client/blob/master/src/main/scala/com.gu.contentapi.client/model/Queries.scala#L108
