### PR TITLE
Better error recovery for SearchQueryIterator

### DIFF
--- a/examples/example.go
+++ b/examples/example.go
@@ -26,9 +26,9 @@ func searchQueryPaged(client *gocapiclient.GuardianContentClient) {
 
 	iterator := client.SearchQueryIterator(searchQuery)
 
-	for response := range iterator {
-		fmt.Println("Page: " + strconv.FormatInt(int64(response.CurrentPage), 10))
-		for _, v := range response.Results {
+	for page := range iterator {
+		fmt.Println("Page: " + strconv.FormatInt(int64(page.SearchResponse.CurrentPage), 10))
+		for _, v := range page.SearchResponse.Results {
 			fmt.Println(v.ID)
 		}
 	}

--- a/queries/search_query.go
+++ b/queries/search_query.go
@@ -54,3 +54,8 @@ func (searchQuery SearchQuery) Deserialize(deser *thrift.TDeserializer, r io.Rea
 
 	return deser.Read(searchQuery.Response, rBytes)
 }
+
+type SearchPageResponse struct {
+	Err            error
+	SearchResponse *content.SearchResponse
+}


### PR DESCRIPTION
No `log.Fatal` returns a `PageResponse` that can capture an error.

Closes the channel after an error.

``` go
type SearchPageResponse struct {
  Err            error
  SearchResponse *content.SearchResponse
}
```
